### PR TITLE
Trying to solve the watch-only address bug

### DIFF
--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -7,6 +7,7 @@
 
 #include <QAbstractTableModel>
 #include <QStringList>
+#include "../script/ismine.h"
 
 class AddressTablePriv;
 class WalletModel;
@@ -87,7 +88,7 @@ private:
 public Q_SLOTS:
     /* Update address list from core.
      */
-    void updateEntry(const QString &address, const QString &label, bool isMine, const QString &purpose, int status);
+    void updateEntry(const QString &address, const QString &label, isminetype isMine, const QString &purpose, int status);
 
     friend class AddressTablePriv;
 };

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -174,7 +174,7 @@ void WalletModel::updateTransaction()
 }
 
 void WalletModel::updateAddressBook(const QString &address, const QString &label,
-        bool isMine, const QString &purpose, int status)
+        isminetype isMine, const QString &purpose, int status)
 {
     if(addressTableModel)
         addressTableModel->updateEntry(address, label, isMine, purpose, status);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -7,6 +7,7 @@
 
 #include "paymentrequestplus.h"
 #include "walletmodeltransaction.h"
+#include "../script/ismine.h"
 
 #include "support/allocators/secure.h"
 
@@ -278,7 +279,7 @@ public Q_SLOTS:
     /* New transaction, or transaction changed status */
     void updateTransaction();
     /* New, updated or removed address book entry */
-    void updateAddressBook(const QString &address, const QString &label, bool isMine, const QString &purpose, int status);
+    void updateAddressBook(const QString &address, const QString &label, isminetype isMine, const QString &purpose, int status);
     /* Watch-only added */
     void updateWatchOnlyFlag(bool fHaveWatchonly);
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */


### PR DESCRIPTION
**Do not merge this yet!**

This is a quick and dirty extension of the routines responsible for filling the address book with addresses. The idea is to use the information returned by isMine() to decide wether to display addresses as receiving addresses. For this, I had to change the signature of two more routines. This might introduce other issues. Someone else, please test this change by starting with a clean wallet and importing a watch-only address. If it does NOT show up in receiving addresses, this fix works. 

It is still debatable if a nicer solution exists to this.
